### PR TITLE
APR-416 changed app interfaces project to .net standard 2.0

### DIFF
--- a/src/SFA.DAS.AdminService.Application.Interfaces/SFA.DAS.AdminService.Application.Interfaces.csproj
+++ b/src/SFA.DAS.AdminService.Application.Interfaces/SFA.DAS.AdminService.Application.Interfaces.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fix for dependency on EPPlus package which does not support .NET Core 2.2