### PR TITLE
APR-1003 - assessor gateway new applications

### DIFF
--- a/src/SFA.DAS.AdminService.Web.Tests/Infrastructure/MappingStartupTests.cs
+++ b/src/SFA.DAS.AdminService.Web.Tests/Infrastructure/MappingStartupTests.cs
@@ -1,0 +1,20 @@
+﻿using AutoMapper;
+using NUnit.Framework;
+using SFA.DAS.AdminService.Web.Infrastructure;
+
+namespace SFA.DAS.AdminService.Web.Tests
+{
+    [TestFixture]
+    public class MappingStartupTests
+    {
+        [Test]
+        public void IsAutomapperConfigurationValid()
+        {
+            Mapper.Reset();
+
+            MappingStartup.AddMappings();
+
+            Mapper.AssertConfigurationIsValid();
+        }
+    }
+}

--- a/src/SFA.DAS.AdminService.Web.sln
+++ b/src/SFA.DAS.AdminService.Web.sln
@@ -31,6 +31,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SFA.DAS.AdminService.Sessio
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SFA.DAS.AdminService.Application.Interfaces", "SFA.DAS.AdminService.Application.Interfaces\SFA.DAS.AdminService.Application.Interfaces.csproj", "{465A90A3-35E8-4820-84F2-735CD78BC0AE}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SFA.DAS.RoatpAssessor", "SFA.DAS.RoatpAssessor\SFA.DAS.RoatpAssessor.csproj", "{E9B3ECC7-025F-4B4C-B1E0-0374BFAFB7DC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SFA.DAS.RoatpAssessor.Tests", "SFA.DAS.RoatpAssessor.Tests\SFA.DAS.RoatpAssessor.Tests.csproj", "{D8DF6983-EA66-441F-8545-825465C19C71}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -85,6 +89,14 @@ Global
 		{465A90A3-35E8-4820-84F2-735CD78BC0AE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{465A90A3-35E8-4820-84F2-735CD78BC0AE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{465A90A3-35E8-4820-84F2-735CD78BC0AE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E9B3ECC7-025F-4B4C-B1E0-0374BFAFB7DC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E9B3ECC7-025F-4B4C-B1E0-0374BFAFB7DC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E9B3ECC7-025F-4B4C-B1E0-0374BFAFB7DC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E9B3ECC7-025F-4B4C-B1E0-0374BFAFB7DC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D8DF6983-EA66-441F-8545-825465C19C71}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D8DF6983-EA66-441F-8545-825465C19C71}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D8DF6983-EA66-441F-8545-825465C19C71}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D8DF6983-EA66-441F-8545-825465C19C71}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -92,6 +104,7 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{F2954FF3-69CA-4C61-995A-59BCC4E94839} = {EFD6034B-FA26-4A09-8FDA-D03C3326560C}
 		{05449B49-D2B3-4F63-B981-544F0AF7B4FF} = {EB54D000-867F-48CA-AE28-BDBE0CCE1322}
+		{D8DF6983-EA66-441F-8545-825465C19C71} = {EB54D000-867F-48CA-AE28-BDBE0CCE1322}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {C5B677B2-0D72-4629-A5FD-F94B00EC858B}

--- a/src/SFA.DAS.AdminService.Web/AutoMapperProfiles/RoatpAssessorProfile.cs
+++ b/src/SFA.DAS.AdminService.Web/AutoMapperProfiles/RoatpAssessorProfile.cs
@@ -1,0 +1,13 @@
+﻿using AutoMapper;
+using SFA.DAS.AdminService.Web.ViewModels.RoatpAssessor.Gateway;
+
+namespace SFA.DAS.AdminService.Web.AutoMapperProfiles
+{
+    public class RoatpAssessorProfile : Profile
+    {
+        public RoatpAssessorProfile()
+        {
+            CreateMap<RoatpAssessor.Domain.DTOs.Application, DashboardApplication>();
+        }
+    }
+}

--- a/src/SFA.DAS.AdminService.Web/Controllers/RoatpAssessor/GatewayController.cs
+++ b/src/SFA.DAS.AdminService.Web/Controllers/RoatpAssessor/GatewayController.cs
@@ -1,5 +1,14 @@
-﻿using Microsoft.AspNetCore.Authorization;
+﻿using AutoMapper;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using SFA.DAS.AdminService.Web.ViewModels.RoatpAssessor.Gateway;
+using SFA.DAS.RoatpAssessor.Application.Gateway;
+using SFA.DAS.RoatpAssessor.Application.Gateway.Requests;
+using System;
+using System.Threading.Tasks;
+using System.Linq;
+using System.Collections.Generic;
 
 namespace SFA.DAS.AdminService.Web.Controllers.RoatpAssessor
 {
@@ -7,10 +16,32 @@ namespace SFA.DAS.AdminService.Web.Controllers.RoatpAssessor
     [Route("roatp-assessor/gateway")]
     public class GatewayController : Controller
     {
-        [HttpGet("dashboard", Name = RouteNames.RoatpAssessor_Gateway_Dashboard_Get)]
-        public IActionResult Dashboard()
+        private readonly IMediator _mediator;
+
+        public GatewayController(IMediator mediator)
         {
-            return View();
+            _mediator = mediator;
+        }
+
+        [HttpGet("dashboard", Name = RouteNames.RoatpAssessor_Gateway_Dashboard_Get)]
+        public async Task<IActionResult> Dashboard([FromQuery]string tab, [FromQuery] string sortBy, [FromQuery] string sort)
+        {
+            if (!Enum.TryParse(tab, out DashboardTab selectedTab))
+                selectedTab = DashboardTab.New;
+
+            var sortDescending = sort == DashboardViewModel.SortDescending;
+            var request = new GetDashboardRequest(selectedTab, sortBy, sortDescending);
+            var response = await _mediator.Send(request);
+
+            var vm = Mapper.Map<DashboardViewModel>(response);
+
+            return View(vm);
+        }
+
+        [HttpPost("{applicationId:Guid}/start-review", Name = RouteNames.RoatpAssessor_Gateway_Start_Review)]
+        public IActionResult StartReview([FromRoute] Guid applicationId)
+        {
+            return RedirectToRoute(RouteNames.RoatpAssessor_Gateway_Dashboard_Get);
         }
     }
 }

--- a/src/SFA.DAS.AdminService.Web/Extensions/DateTimeExtensions.cs
+++ b/src/SFA.DAS.AdminService.Web/Extensions/DateTimeExtensions.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace SFA.DAS.AdminService.Web.Extensions
+{
+    public static class DateTimeExtensions
+    {
+        private const string DisplayDateFormat = "dd MMM yyyy";
+
+        public static string ToGdsDate(this DateTime datetime)
+        {
+            return datetime.ToString(DisplayDateFormat);
+        }
+    }
+}

--- a/src/SFA.DAS.AdminService.Web/Infrastructure/MappingStartup.cs
+++ b/src/SFA.DAS.AdminService.Web/Infrastructure/MappingStartup.cs
@@ -17,6 +17,7 @@ namespace SFA.DAS.AdminService.Web.Infrastructure
                     );
 
                 cfg.AddProfile<RegisterViewAndEditUserViewModelProfile>();
+                cfg.AddProfile<RoatpAssessorProfile>();
             });
         }
     }

--- a/src/SFA.DAS.AdminService.Web/RouteNames.cs
+++ b/src/SFA.DAS.AdminService.Web/RouteNames.cs
@@ -16,5 +16,6 @@ namespace SFA.DAS.AdminService.Web
 
         //RoatpAssesssor
         public const string RoatpAssessor_Gateway_Dashboard_Get = "RoatpAssessor_Gateway_Dashboard_Get";
+        public const string RoatpAssessor_Gateway_Start_Review = "RoatpAssessor_Gateway_Start_Review";
     }
 }

--- a/src/SFA.DAS.AdminService.Web/SFA.DAS.AdminService.Web.csproj
+++ b/src/SFA.DAS.AdminService.Web/SFA.DAS.AdminService.Web.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="FluentValidation" Version="8.4.0" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="8.4.0" />
     <PackageReference Include="Humanizer.Core" Version="2.4.2" />
+    <PackageReference Include="MediatR" Version="7.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="AutoMapper" Version="7.0.1" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.3.0" />
@@ -46,6 +47,7 @@
     <ProjectReference Include="..\SFA.DAS.AssessorService.Application.Api.Client\SFA.DAS.AssessorService.Application.Api.Client.csproj" />
     <ProjectReference Include="..\SFA.DAS.AssessorService.ApplyTypes\SFA.DAS.AssessorService.ApplyTypes.csproj" />
     <ProjectReference Include="..\SFA.DAS.AssessorService.Domain\SFA.DAS.AssessorService.Domain.csproj" />
+    <ProjectReference Include="..\SFA.DAS.RoatpAssessor\SFA.DAS.RoatpAssessor.csproj" />
   </ItemGroup>
 
   <ItemGroup>
@@ -154,6 +156,9 @@
       <Pack>$(IncludeRazorContentInPack)</Pack>
     </Content>
     <Content Update="Views\Reports\_ReportScriptsPartial.cshtml">
+      <Pack>$(IncludeRazorContentInPack)</Pack>
+    </Content>
+    <Content Update="Views\RoatpAssessor\_ViewImports.cshtml">
       <Pack>$(IncludeRazorContentInPack)</Pack>
     </Content>
     <Content Update="Views\Roatp\AddApplicationDeterminedDate.cshtml">

--- a/src/SFA.DAS.AdminService.Web/Startup.cs
+++ b/src/SFA.DAS.AdminService.Web/Startup.cs
@@ -116,7 +116,9 @@ namespace SFA.DAS.AdminService.Web
             services.AddHealthChecks();
             MappingStartup.AddMappings();
             
-            ConfigureDependencyInjection(services);           
+            ConfigureDependencyInjection(services);
+
+            RoatpAssessor.Configuration.IoC.ConfigureServices(ApplicationConfiguration.ApplyApiAuthentication, services);
         }
 
         private void ConfigureDependencyInjection(IServiceCollection services)

--- a/src/SFA.DAS.AdminService.Web/ViewModels/RoatpAssessor/Gateway/DashboardViewModel.cs
+++ b/src/SFA.DAS.AdminService.Web/ViewModels/RoatpAssessor/Gateway/DashboardViewModel.cs
@@ -1,0 +1,58 @@
+﻿using SFA.DAS.RoatpAssessor.Application.Gateway;
+using System;
+using System.Collections.Generic;
+
+namespace SFA.DAS.AdminService.Web.ViewModels.RoatpAssessor.Gateway
+{
+    public class DashboardViewModel
+    {
+        public const string SortDescending = "desc";
+        private const string SelectedTabCss = "govuk-tabs__tab--selected";
+
+        public DashboardTab Tab { get; set; }
+        public List<DashboardApplication> NewApplications { get; set; }
+        public int NewApplicationsCount { get; set; }
+        public int InProgressCount { get; set; }
+        public string SortedBy { get; set; }
+        public bool SortedDescending { get; set; }
+
+        public string NewApplicationsTabCss => Tab == DashboardTab.New
+            ? SelectedTabCss : "";
+
+        public string InProgressTabCss => Tab == DashboardTab.InProgress
+            ? SelectedTabCss : "";
+
+        public string OutcomesTabCss => Tab == DashboardTab.Outcomes
+            ? SelectedTabCss : "";
+
+
+        public string SearchTabCss => Tab == DashboardTab.Search
+            ? SelectedTabCss : "";
+
+        public string GetRouteSort(string sortBy)
+        {
+            if (sortBy != SortedBy)
+                return null;
+
+            return SortedDescending ? null : SortDescending;
+        }
+
+        public string GetAriaSort(string sortBy)
+        {
+            if (sortBy != SortedBy)
+                return null;
+
+            return SortedDescending ? "descending" : "ascending";
+        }
+    }
+
+    public class DashboardApplication
+    {
+        public Guid Id { get; set; }
+        public string OrganisationName { get; set; }
+        public string Ukprn { get; set; }
+        public string ApplicationRef { get; set; }
+        public string ProviderRoute { get; set; }
+        public DateTime SubmittedAt { get; set; }
+    }
+}

--- a/src/SFA.DAS.AdminService.Web/Views/RoatpAssessor/Gateway/Dashboard.cshtml
+++ b/src/SFA.DAS.AdminService.Web/Views/RoatpAssessor/Gateway/Dashboard.cshtml
@@ -1,6 +1,13 @@
-﻿<partial name="_RoatpBreadcrumb" />
+﻿@using SFA.DAS.AdminService.Web.Extensions
+@using SFA.DAS.RoatpAssessor.Application.Gateway;
+@using SFA.DAS.AdminService.Web.ViewModels.RoatpAssessor.Gateway;
+@using SFA.DAS.RoatpAssessor.Domain.DTOs;
 
-<main class="govuk-main-wrapper " id="main-content" role="main">
+@model DashboardViewModel
+
+<partial name="_RoatpBreadcrumb" />
+
+<main class="govuk-main-wrapper roatp-assessor-dashboard" id="main-content" role="main">
 
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
@@ -9,59 +16,129 @@
         </div>
     </div>
 
-    <div class="govuk-tabs" data-module="tabs">
+    <div class="govuk-tabs">
         <h2 class="govuk-tabs__title">
             Contents
         </h2>
 
         <ul class="govuk-tabs__list">
             <li class="govuk-tabs__list-item">
-                <a class="govuk-tabs__tab govuk-tabs__tab--selected" href="#new">
-                    New (todo)
+                <a asp-route="@RouteNames.RoatpAssessor_Gateway_Dashboard_Get" asp-route-tab="@nameof(DashboardTab.New)" class="govuk-tabs__tab @Model.NewApplicationsTabCss">
+                    New (@Model.NewApplicationsCount)
                 </a>
             </li>
             <li class="govuk-tabs__list-item">
-                <a class="govuk-tabs__tab" href="#inprogress">
-                    In progress (todo)
-                </a>
-            </li>
-
-
-            <li class="govuk-tabs__list-item">
-                <a class="govuk-tabs__tab" href="#gateway-outcomes">
-                    Gateway outcomes (todo)
+                <a asp-route="@RouteNames.RoatpAssessor_Gateway_Dashboard_Get" asp-route-tab="@nameof(DashboardTab.InProgress)" class="govuk-tabs__tab @Model.InProgressTabCss">
+                    In progress (@Model.InProgressCount)
                 </a>
             </li>
             <li class="govuk-tabs__list-item">
-                <a class="govuk-tabs__tab" href="#search">
-                    Search applications (todo)
+                <a asp-route="@RouteNames.RoatpAssessor_Gateway_Dashboard_Get" asp-route-tab="@nameof(DashboardTab.Outcomes)" class="govuk-tabs__tab @Model.OutcomesTabCss">
+                    Gateway outcomes
+                </a>
+            </li>
+            <li class="govuk-tabs__list-item">
+                <a asp-route="@RouteNames.RoatpAssessor_Gateway_Dashboard_Get" asp-route-tab="@nameof(DashboardTab.Search)" class="govuk-tabs__tab @Model.SearchTabCss">
+                    Search applications
                 </a>
             </li>
         </ul>
 
-        <section class="govuk-tabs__panel" id="new">
+        @if (Model.Tab == DashboardTab.New)
+        {
+            <section class="govuk-tabs__panel">
 
-            <h2 class="govuk-heading-l">New</h2>
+                <h2 class="govuk-heading-l">New</h2>
+                <table class="govuk-table govuk-!-font-size-16">
+                    <thead class="govuk-table__head">
+                        <tr class="govuk-table__row">
+                            <th class="govuk-table__header">
+                                <a aria-sort="@Model.GetAriaSort(nameof(Application.OrganisationName))"
+                                   asp-route="@RouteNames.RoatpAssessor_Gateway_Dashboard_Get"
+                                   asp-route-tab="@nameof(DashboardTab.New)"
+                                   asp-route-sortBy="@nameof(Application.OrganisationName)"
+                                   asp-route-sort="@Model.GetRouteSort(nameof(Application.OrganisationName))">Organisation name</a>
+                            </th>
+                            <th class="govuk-table__header">
+                                <a aria-sort="@Model.GetAriaSort(nameof(Application.Ukprn))"
+                                   asp-route="@RouteNames.RoatpAssessor_Gateway_Dashboard_Get"
+                                   asp-route-tab="@nameof(DashboardTab.New)"
+                                   asp-route-sortBy="@nameof(Application.Ukprn)"
+                                   asp-route-sort="@Model.GetRouteSort(nameof(Application.Ukprn))">UKPRN</a>
+                            </th>
+                            <th class="govuk-table__header">
+                                <a aria-sort="@Model.GetAriaSort(nameof(Application.ApplicationRef))"
+                                   asp-route="@RouteNames.RoatpAssessor_Gateway_Dashboard_Get"
+                                   asp-route-tab="@nameof(DashboardTab.New)"
+                                   asp-route-sortBy="@nameof(Application.ApplicationRef)"
+                                   asp-route-sort="@Model.GetRouteSort(nameof(Application.ApplicationRef))">Application<br/>reference number</a>
+                            </th>
+                            <th class="govuk-table__header">
+                                <a aria-sort="@Model.GetAriaSort(nameof(Application.ProviderRoute))"
+                                   asp-route="@RouteNames.RoatpAssessor_Gateway_Dashboard_Get"
+                                   asp-route-tab="@nameof(DashboardTab.New)"
+                                   asp-route-sortBy="@nameof(Application.ProviderRoute)"
+                                   asp-route-sort="@Model.GetRouteSort(nameof(Application.ProviderRoute))">Provider route</a>
+                            </th>
+                            <th class="govuk-table__header">
+                                <a aria-sort="@Model.GetAriaSort(nameof(Application.SubmittedAt))"
+                                   asp-route="@RouteNames.RoatpAssessor_Gateway_Dashboard_Get"
+                                   asp-route-tab="@nameof(DashboardTab.New)"
+                                   asp-route-sortBy="@nameof(Application.SubmittedAt)"
+                                   asp-route-sort="@Model.GetRouteSort(nameof(Application.SubmittedAt))">Application submitted</a>
+                            </th>
+                            <th class="govuk-table__header"></th>
+                        </tr>
+                    </thead>
+                    <tbody class="govuk-table__body">
+                        @foreach (var application in Model.NewApplications)
+                        {
+                        <tr class="govuk-table__row">
+                            <td class="govuk-table__cell">@application.OrganisationName</td>
+                            <td class="govuk-table__cell">@application.Ukprn</td>
+                            <td class="govuk-table__cell">@application.ApplicationRef</td>
+                            <td class="govuk-table__cell">@application.ProviderRoute</td>
+                            <td class="govuk-table__cell">@application.SubmittedAt.ToGdsDate()</td>
+                            <td class="govuk-table__cell">
+                                <form asp-route="@RouteNames.RoatpAssessor_Gateway_Start_Review" asp-route-applicationId="@application.Id">
+                                    <button type="submit" class="govuk-button--looks-like-link  govuk-!-font-size-16">Assign to me</button>
+                                </form>
+                            </td>
+                        </tr>
+                        }
+                    </tbody>
+                </table>
 
-        </section>
+            </section>
+        }
 
-        <section class="govuk-tabs__panel govuk-tabs__panel--hidden" id="inprogress">
+        @if (Model.Tab == DashboardTab.InProgress)
+        {
+            <section class="govuk-tabs__panel">
 
-            <h2 class="govuk-heading-l">In progress</h2>
-            
-        </section>
+                <h2 class="govuk-heading-l">In progress</h2>
 
-        <section class="govuk-tabs__panel govuk-tabs__panel--hidden" id="gateway-outcomes">
+            </section>
+        }
 
-            <h2 class="govuk-heading-l">Gateway outcomes</h2>
-            
-        </section>
+        @if (Model.Tab == DashboardTab.Outcomes)
+        {
+            <section class="govuk-tabs__panel">
 
+                <h2 class="govuk-heading-l">Gateway outcomes</h2>
 
-        <section class="govuk-tabs__panel govuk-tabs__panel--hidden" id="search">
+            </section>
+        }
 
-            <h2 class="govuk-heading-l">Search applications</h2>
-            
-        </section>
+        @if (Model.Tab == DashboardTab.Search)
+        {
+
+            <section class="govuk-tabs__panel">
+
+                <h2 class="govuk-heading-l">Search applications</h2>
+
+            </section>
+        }
+
     </div>
 </main>

--- a/src/SFA.DAS.AdminService.Web/Views/RoatpAssessor/_ViewImports.cshtml
+++ b/src/SFA.DAS.AdminService.Web/Views/RoatpAssessor/_ViewImports.cshtml
@@ -1,0 +1,1 @@
+@addTagHelper *, SFA.DAS.AdminService.Web.TagHelpers.RoatpAssessor

--- a/src/SFA.DAS.AdminService.Web/wwwroot/stylesheets/application.css
+++ b/src/SFA.DAS.AdminService.Web/wwwroot/stylesheets/application.css
@@ -1525,3 +1525,24 @@ TODO: change to 'das-page-navigation' and BEM
 .roatp-search-panel {
   background-color: #f8f8f8;
 }
+
+
+.roatp-assessor-dashboard [aria-sort="descending"]:after {
+    content: " \25bc";
+    font-size: .8em;
+}
+
+.roatp-assessor-dashboard [aria-sort="ascending"]:after {
+    content: " \25b2";
+    font-size: .8em;
+}
+
+.roatp-assessor-dashboard th a {
+    text-decoration: none;
+    color: #005ea5;
+}
+
+.roatp-assessor-dashboard th a {
+    color: #005ea5;
+}
+

--- a/src/SFA.DAS.AssessorService.Application.Api.Client/ITokenService.cs
+++ b/src/SFA.DAS.AssessorService.Application.Api.Client/ITokenService.cs
@@ -8,4 +8,8 @@
     public interface IQnaTokenService : ITokenService
     {
     }
+
+    public interface IApplyTokenService : ITokenService
+    {
+    }
 }

--- a/src/SFA.DAS.RoatpAssessor.Tests/Application/Gateway/Requests/GetDashboardHandlerTests.cs
+++ b/src/SFA.DAS.RoatpAssessor.Tests/Application/Gateway/Requests/GetDashboardHandlerTests.cs
@@ -1,0 +1,57 @@
+﻿using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using SFA.DAS.RoatpAssessor.Application;
+using SFA.DAS.RoatpAssessor.Application.Gateway.Requests;
+using SFA.DAS.RoatpAssessor.Domain.DTOs;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using RoatpApplication = SFA.DAS.RoatpAssessor.Domain.DTOs.Application;
+
+namespace SFA.DAS.RoatpAssessor.Tests.Application.Gateway.Requests
+{
+    [TestFixture]
+    public class GetDashboardHandlerTests
+    {
+        [TestCase(nameof(RoatpApplication.OrganisationName), false, "a", "b", "c", "d","e")]
+        [TestCase(nameof(RoatpApplication.OrganisationName), true, "e", "d", "c", "b", "a")]
+        [TestCase(nameof(RoatpApplication.Ukprn), false, "e", "a", "d", "c", "b")]
+        [TestCase(nameof(RoatpApplication.Ukprn), true, "b", "c", "d", "a", "e")]
+        [TestCase(nameof(RoatpApplication.ApplicationRef), false, "d", "b", "a", "e", "c")]
+        [TestCase(nameof(RoatpApplication.ApplicationRef), true, "c", "e", "a", "b", "d")]
+        [TestCase(nameof(RoatpApplication.ProviderRoute), false, "b", "d", "e", "c", "a")]
+        [TestCase(nameof(RoatpApplication.ProviderRoute), true, "a", "c", "e", "d", "b")]
+        [TestCase(nameof(RoatpApplication.SubmittedAt), false, "c", "e", "b", "a", "d")]
+        [TestCase(nameof(RoatpApplication.SubmittedAt), true, "d", "a", "b", "e", "c")]
+        public async Task ShouldOrderNewApplications(string sortBy, bool sortDescending, string first, string second, string third, string fourth, string fifth)
+        {
+            var applyApiClientMock = new Mock<IApplyApiClient>();
+            applyApiClientMock.Setup(a => a.GetGatewayCounts())
+                .ReturnsAsync(new GatewayCounts());
+
+            applyApiClientMock.Setup(a => a.GetSubmittedApplicationsAsync())
+                .ReturnsAsync(new List<RoatpApplication>
+                {
+                    new RoatpApplication{OrganisationName = "b", Ukprn = "5", ApplicationRef = "refb", ProviderRoute = "rte1", SubmittedAt = DateTime.Parse("2003-01-01")},
+                    new RoatpApplication{OrganisationName = "e", Ukprn = "1", ApplicationRef = "refd", ProviderRoute = "rte3", SubmittedAt = DateTime.Parse("2002-01-01")},
+                    new RoatpApplication{OrganisationName = "a", Ukprn = "2", ApplicationRef = "refc", ProviderRoute = "rte5", SubmittedAt = DateTime.Parse("2004-01-01")},
+                    new RoatpApplication{OrganisationName = "c", Ukprn = "4", ApplicationRef = "refe", ProviderRoute = "rte4", SubmittedAt = DateTime.Parse("2001-01-01")},
+                    new RoatpApplication{OrganisationName = "d", Ukprn = "3", ApplicationRef = "refa", ProviderRoute = "rte2", SubmittedAt = DateTime.Parse("2005-01-01")}
+                });
+
+            var handler = new GetDashboardHandler(applyApiClientMock.Object);
+
+            var request = new GetDashboardRequest(RoatpAssessor.Application.Gateway.DashboardTab.New, sortBy, sortDescending);
+
+            var response = await handler.Handle(request, new CancellationToken());
+
+            response.NewApplications[0].OrganisationName.Should().Be(first);
+            response.NewApplications[1].OrganisationName.Should().Be(second);
+            response.NewApplications[2].OrganisationName.Should().Be(third);
+            response.NewApplications[3].OrganisationName.Should().Be(fourth);
+            response.NewApplications[4].OrganisationName.Should().Be(fifth);
+        }
+    }
+}

--- a/src/SFA.DAS.RoatpAssessor.Tests/SFA.DAS.RoatpAssessor.Tests.csproj
+++ b/src/SFA.DAS.RoatpAssessor.Tests/SFA.DAS.RoatpAssessor.Tests.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="5.9.0" />
+    <PackageReference Include="Moq" Version="4.8.2" />
+    <PackageReference Include="nunit" Version="3.10.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SFA.DAS.RoatpAssessor\SFA.DAS.RoatpAssessor.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/SFA.DAS.RoatpAssessor/Application/Gateway/DashboardTab.cs
+++ b/src/SFA.DAS.RoatpAssessor/Application/Gateway/DashboardTab.cs
@@ -1,0 +1,10 @@
+﻿namespace SFA.DAS.RoatpAssessor.Application.Gateway
+{
+    public enum DashboardTab
+    {
+        New,
+        InProgress,
+        Outcomes,
+        Search
+    };
+}

--- a/src/SFA.DAS.RoatpAssessor/Application/Gateway/Requests/GetDashboardHandler.cs
+++ b/src/SFA.DAS.RoatpAssessor/Application/Gateway/Requests/GetDashboardHandler.cs
@@ -1,0 +1,79 @@
+﻿using MediatR;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using RoatpApplication = SFA.DAS.RoatpAssessor.Domain.DTOs.Application;
+
+namespace SFA.DAS.RoatpAssessor.Application.Gateway.Requests
+{
+    public class GetDashboardHandler : IRequestHandler<GetDashboardRequest, GetDashboardResponse>
+    {
+        private readonly IApplyApiClient _applyApiClient;
+
+        public GetDashboardHandler(IApplyApiClient applyApiClient)
+        {
+            _applyApiClient = applyApiClient;
+        }
+
+        public async Task<GetDashboardResponse> Handle(GetDashboardRequest request, CancellationToken cancellationToken)
+        {
+            var countsTask = _applyApiClient.GetGatewayCounts();
+
+            var newApplicationsTask = request.Tab == DashboardTab.New 
+                ? _applyApiClient.GetSubmittedApplicationsAsync() 
+                : Task.FromResult(new List<RoatpApplication>());
+
+            await Task.WhenAll(countsTask, newApplicationsTask);
+
+            var newApplications = SortApplications(newApplicationsTask.Result, request.SortBy, request.SortDescending);
+
+            var response = new GetDashboardResponse
+            {
+                Tab = request.Tab,
+                NewApplicationsCount = countsTask.Result.NewApplications,
+                InProgressCount = countsTask.Result.InProgress,
+                NewApplications = newApplications,
+                SortedBy = request.SortBy ?? nameof(RoatpApplication.SubmittedAt),
+                SortedDescending = request.SortDescending
+            };
+           
+            return response;
+        }
+
+        private List<RoatpApplication> SortApplications(List<RoatpApplication> applications, string sortBy, bool sortDescending)
+        {
+            if (applications == null)
+                return null;
+
+            switch (sortBy)
+            {
+                case nameof(RoatpApplication.OrganisationName):
+                    return sortDescending
+                        ? applications.OrderByDescending(a => a.OrganisationName).ToList()
+                        : applications.OrderBy(a => a.OrganisationName).ToList();
+
+                case nameof(RoatpApplication.Ukprn):
+                    return sortDescending
+                        ? applications.OrderByDescending(a => a.Ukprn).ToList()
+                        : applications.OrderBy(a => a.Ukprn).ToList();
+
+                case nameof(RoatpApplication.ApplicationRef):
+                    return sortDescending
+                        ? applications.OrderByDescending(a => a.ApplicationRef).ToList()
+                        : applications.OrderBy(a => a.ApplicationRef).ToList();
+
+                case nameof(RoatpApplication.ProviderRoute):
+                    return sortDescending
+                        ? applications.OrderByDescending(a => a.ProviderRoute).ToList()
+                        : applications.OrderBy(a => a.ProviderRoute).ToList();
+
+                case nameof(RoatpApplication.SubmittedAt):
+                default:
+                    return sortDescending
+                        ? applications.OrderByDescending(a => a.SubmittedAt).ToList()
+                        : applications.OrderBy(a => a.SubmittedAt).ToList();
+            }
+        }
+    }
+}

--- a/src/SFA.DAS.RoatpAssessor/Application/Gateway/Requests/GetDashboardRequest.cs
+++ b/src/SFA.DAS.RoatpAssessor/Application/Gateway/Requests/GetDashboardRequest.cs
@@ -1,0 +1,18 @@
+﻿using MediatR;
+
+namespace SFA.DAS.RoatpAssessor.Application.Gateway.Requests
+{
+    public class GetDashboardRequest : IRequest<GetDashboardResponse>
+    {
+        public DashboardTab Tab { get; }
+        public bool SortDescending { get; }
+        public string SortBy { get; }
+
+        public GetDashboardRequest(DashboardTab tab, string sortBy, bool sortDescending)
+        {
+            Tab = tab;
+            SortDescending = sortDescending;
+            SortBy = sortBy;
+        }
+    }
+}

--- a/src/SFA.DAS.RoatpAssessor/Application/Gateway/Requests/GetDashboardResponse.cs
+++ b/src/SFA.DAS.RoatpAssessor/Application/Gateway/Requests/GetDashboardResponse.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.Generic;
+
+namespace SFA.DAS.RoatpAssessor.Application.Gateway.Requests
+{
+    public class GetDashboardResponse
+    {
+        public DashboardTab Tab { get; set; }
+        public List<Domain.DTOs.Application> NewApplications { get; set; }
+        public string SortedBy { get; set; }
+        public bool SortedDescending { get; set; }
+        public int NewApplicationsCount { get; set; }
+        public int InProgressCount { get; set; }
+    }
+}

--- a/src/SFA.DAS.RoatpAssessor/Application/IApplyApiClient.cs
+++ b/src/SFA.DAS.RoatpAssessor/Application/IApplyApiClient.cs
@@ -1,0 +1,12 @@
+﻿using SFA.DAS.RoatpAssessor.Domain.DTOs;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace SFA.DAS.RoatpAssessor.Application
+{
+    public interface IApplyApiClient
+    {
+        Task<List<Domain.DTOs.Application>> GetSubmittedApplicationsAsync();
+        Task<GatewayCounts> GetGatewayCounts();
+    }
+}

--- a/src/SFA.DAS.RoatpAssessor/Configuration/IoC.cs
+++ b/src/SFA.DAS.RoatpAssessor/Configuration/IoC.cs
@@ -1,0 +1,25 @@
+﻿using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using SFA.DAS.AdminService.Settings;
+using SFA.DAS.AssessorService.Application.Api.Client;
+using SFA.DAS.RoatpAssessor.Application;
+using SFA.DAS.RoatpAssessor.Services;
+
+namespace SFA.DAS.RoatpAssessor.Configuration
+{
+    public static class IoC
+    {
+        public static void ConfigureServices(ClientApiAuthentication applyApiAuthentication, IServiceCollection services)
+        {
+            services.AddMediatR(typeof(IoC).Assembly);
+
+            services.AddTransient<IApplyTokenService, ApplyTokenService>();
+
+            services.AddTransient<IApplyApiClient>(x => new ApplyApiClient(
+              applyApiAuthentication.ApiBaseAddress,
+              x.GetService<IApplyTokenService>(),
+              x.GetService<ILogger<ApplyApiClient>>()));
+        }
+    }
+}

--- a/src/SFA.DAS.RoatpAssessor/Domain/DTOs/Application.cs
+++ b/src/SFA.DAS.RoatpAssessor/Domain/DTOs/Application.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace SFA.DAS.RoatpAssessor.Domain.DTOs
+{
+    public class Application
+    {
+        public Guid Id { get; set; }
+        public string ApplicationStatus { get; set; }
+
+        //todo: These values need to be trapped at point of application submission
+        public string OrganisationName { get; set; } = "My TODO ORG";
+        public string Ukprn { get; set; } = "12345678";
+        public string ApplicationRef { get; set; } = "APR00000001";
+        public string ProviderRoute { get; set; } = "Main (todo)";
+        public DateTime SubmittedAt { get; set; } = DateTime.Parse("2018-01-01");
+    }
+}

--- a/src/SFA.DAS.RoatpAssessor/Domain/DTOs/GatewayCounts.cs
+++ b/src/SFA.DAS.RoatpAssessor/Domain/DTOs/GatewayCounts.cs
@@ -1,0 +1,8 @@
+﻿namespace SFA.DAS.RoatpAssessor.Domain.DTOs
+{
+    public class GatewayCounts
+    {
+        public int NewApplications { get; set; }
+        public int InProgress { get; set; }
+    }
+}

--- a/src/SFA.DAS.RoatpAssessor/SFA.DAS.RoatpAssessor.csproj
+++ b/src/SFA.DAS.RoatpAssessor/SFA.DAS.RoatpAssessor.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Folder Include="Application\Gateway\Commands\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MediatR" Version="7.0.0" />
+    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="7.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SFA.DAS.AssessorService.Application.Api.Client\SFA.DAS.AssessorService.Application.Api.Client.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/SFA.DAS.RoatpAssessor/Services/ApplyApiClient.cs
+++ b/src/SFA.DAS.RoatpAssessor/Services/ApplyApiClient.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.Extensions.Logging;
+using SFA.DAS.AssessorService.Application.Api.Client;
+using SFA.DAS.AssessorService.Application.Api.Client.Clients;
+using SFA.DAS.RoatpAssessor.Application;
+using SFA.DAS.RoatpAssessor.Domain.DTOs;
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace SFA.DAS.RoatpAssessor.Services
+{
+    public class ApplyApiClient : ApiClientBase, IApplyApiClient
+    {
+        private readonly ILogger<ApplyApiClient> _logger;
+
+        public ApplyApiClient(string baseUri, IApplyTokenService tokenService, ILogger<ApplyApiClient> logger)
+            : base(baseUri, tokenService, logger)
+        {
+            _logger = logger;
+        }
+
+        public Task<List<Domain.DTOs.Application>> GetSubmittedApplicationsAsync()
+        {
+            using (var request = new HttpRequestMessage(HttpMethod.Get, $"/roatp-assessor/applications/submitted"))
+            {
+                return RequestAndDeserialiseAsync<List<Domain.DTOs.Application>>(request);
+            }
+        }
+
+        public Task<GatewayCounts> GetGatewayCounts()
+        {
+            using (var request = new HttpRequestMessage(HttpMethod.Get, $"roatp-assessor/gateway/counts"))
+            {
+                return RequestAndDeserialiseAsync<GatewayCounts>(request);
+            }
+        }
+    }
+}

--- a/src/SFA.DAS.RoatpAssessor/Services/ApplyTokenServices.cs
+++ b/src/SFA.DAS.RoatpAssessor/Services/ApplyTokenServices.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.Extensions.Hosting;
+using Microsoft.IdentityModel.Clients.ActiveDirectory;
+using SFA.DAS.AdminService.Settings;
+using SFA.DAS.AssessorService.Application.Api.Client;
+
+namespace SFA.DAS.RoatpAssessor.Services
+{
+    public class ApplyTokenService : IApplyTokenService
+    {
+        private readonly IWebConfiguration _configuration;
+        private readonly IHostingEnvironment _hostingEnvironment;
+        public ApplyTokenService(IWebConfiguration configuration, IHostingEnvironment hostingEnvironment)
+        {
+            _configuration = configuration;
+            _hostingEnvironment = hostingEnvironment;
+        }
+
+        public string GetToken()
+        {
+            if (_hostingEnvironment.IsDevelopment())
+                return string.Empty;
+
+            var tenantId = _configuration.ApplyApiAuthentication.TenantId;
+            var clientId = _configuration.ApplyApiAuthentication.ClientId;
+            var appKey = _configuration.ApplyApiAuthentication.ClientSecret;
+            var resourceId = _configuration.ApplyApiAuthentication.ResourceId;
+
+            var authority = $"https://login.microsoftonline.com/{tenantId}";
+            var clientCredential = new ClientCredential(clientId, appKey);
+            var context = new AuthenticationContext(authority, true);
+            var result = context.AcquireTokenAsync(resourceId, clientCredential).Result;
+
+            return result.AccessToken;
+        }
+    }
+}


### PR DESCRIPTION
- Added Mediatr to `SFA.DAS.AdminService.Web`
- Added new library `SFA.DAS.RoatpAssessor` and accompanying test project
- Added `ApplyApiClient` to communicate with `Apply.InternalApi`
- Added Unit Test to assert AutoMapper config is correct.

Functionality wise this introduces a Dashboard view for the Gateway team.  It a series of tabs one of which displays a table of new applications (applications in a submitted state).  It also displays a count of applications that are 'new' and 'in progress'. The table is sortable by clicking the headings.