### PR TITLE
Adds globbing to remove library javascript from SonarCloud analysis

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -45,6 +45,7 @@ stages:
         scannerMode: 'MSBuild'
         projectName: "$(Build.DefinitionName)"
         projectKey: "$(sonarCloudProjectKey)"
+        extraProperties: sonar.exclusions=**/SFA.DAS.AdminService.Web/wwwroot/javascripts/lib/**/*,**/SFA.DAS.AdminService.Web/wwwroot/lib/**/*
 
     - task: DotNetCoreCLI@2
       displayName: 'dotnet restore'


### PR DESCRIPTION
Exclude library javascript files from SonarCloud analysis by including the sonar.exclusions property on the SonarCloudPrepare@1 task of the build.

As javascript library files will never be "fixed" by the Service there is no value in us analysing them.