### PR TITLE
SV-913 Withdrawal Application Overview Page

### DIFF
--- a/src/SFA.DAS.AdminService.Web/Views/Application/Sequence.cshtml
+++ b/src/SFA.DAS.AdminService.Web/Views/Application/Sequence.cshtml
@@ -69,7 +69,7 @@
                         var standardAndVersion = Model.StandardName;
                         if (!string.IsNullOrWhiteSpace(Model.StandardVersion))
                         {
-                            standardAndVersion = $"{standardAndVersion}<br>Version {String.Join(",", Model.StandardVersion)}";
+                            standardAndVersion = $"{standardAndVersion}<br>Version {Model.StandardVersion}";
                         }
 
                         <div class="govuk-summary-list__row">

--- a/src/SFA.DAS.AdminService.Web/Views/Application/Sequence.cshtml
+++ b/src/SFA.DAS.AdminService.Web/Views/Application/Sequence.cshtml
@@ -64,11 +64,17 @@
                             <dd class="govuk-summary-list__value">@Model.StandardVersion</dd>
                         </div>
                     }
-                    @if (!string.IsNullOrWhiteSpace(Model.StandardWithReference) && Model.SequenceNo == ApplyConst.STANDARD_WITHDRAWAL_SEQUENCE_NO)
+                    @if (!string.IsNullOrWhiteSpace(Model.StandardName) && Model.SequenceNo == ApplyConst.STANDARD_WITHDRAWAL_SEQUENCE_NO)
                     {
+                        var standardAndVersion = Model.StandardName;
+                        if (!string.IsNullOrWhiteSpace(Model.StandardVersion))
+                        {
+                            standardAndVersion = $"{standardAndVersion}<br>Version {String.Join(",", Model.StandardVersion)}";
+                        }
+
                         <div class="govuk-summary-list__row">
                             <dt class="govuk-summary-list__key">Details</dt>
-                            <dd class="govuk-summary-list__value">@Model.StandardWithReference</dd>
+                            <dd class="govuk-summary-list__value">@Html.Raw(standardAndVersion)</dd>
                         </div>
                     }
                     @if (Model.SequenceNo == ApplyConst.ORGANISATION_WITHDRAWAL_SEQUENCE_NO)


### PR DESCRIPTION
In the tech huddle we discussed about showing some text such as "all versions" if the application is to withdraw from the standard completely. Looking at the way the UI interacts with the API this doesn't appear to be a quick win to achieve, so for now it's displaying the version numbers as per the requirement. If the story gets completed before the deadline and there is time remaining, I can come back to enhance it.