### PR TITLE
Fix bug when withdrawing from a standard completely

### DIFF
--- a/src/SFA.DAS.AdminService.Web/Controllers/Apply/ApplicationController.cs
+++ b/src/SFA.DAS.AdminService.Web/Controllers/Apply/ApplicationController.cs
@@ -326,10 +326,16 @@ namespace SFA.DAS.AdminService.Web.Controllers.Apply
                 {
                     await UpdateOrganisationStandardWithdrawalDate(organisation.EndPointAssessorOrganisationId, null, null, sequenceVm.RequestedWithdrawalDate.Value);
                 }
+                else if (null == sequenceVm.Versions || !sequenceVm.Versions.Any())
+                {
+                    // No versions supplied in the withdrawal application means they are withdrawing from the standard completely
+                    await UpdateOrganisationStandardWithdrawalDate(organisation.EndPointAssessorOrganisationId, sequenceVm.StandardReference, null, sequenceVm.RequestedWithdrawalDate.Value);
+                }
                 else
                 {
                     await UpdateOrganisationStandardWithdrawalDate(organisation.EndPointAssessorOrganisationId, sequenceVm.StandardReference, sequenceVm.Versions[sequenceVm.CurrentVersionIndex.Value], sequenceVm.RequestedWithdrawalDate.Value);
                 }
+
 
                 sequenceVm.IncrementCurrentVersionIndex();
                 if(sequenceVm.CurrentVersionIndex.HasValue)


### PR DESCRIPTION
When withdrawing from a standard completely, the versions list is null. This was causing a null reference exception. Code copied from previous fix (looks like something got lost in the big merge / rebasing exercise for 596).