### PR TITLE
updated das-platform-building-blocks to 2.1.28

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,7 +17,7 @@ resources:
   - repository: das-platform-building-blocks
     type: github
     name: SkillsFundingAgency/das-platform-building-blocks
-    ref: refs/tags/2.1.0
+    ref: refs/tags/2.1.28
     endpoint: SkillsFundingAgency
 
 stages:
@@ -33,6 +33,7 @@ stages:
     - template: azure-pipelines-templates/build/step/app-build.yml@das-platform-building-blocks
       parameters:
         SonarCloudProjectKey: SkillsFundingAgency_das-admin-service
+        ContinueOnVulnerablePackageScanError: true
 
     - task: DotNetCoreCLI@2
       displayName: 'dotnet pack'


### PR DESCRIPTION
Upgrading seems to have had no adverse effects:
Build:
https://sfa-gov-uk.visualstudio.com/Digital%20Apprenticeship%20Service/_build/results?buildId=814362&view=logs&s=6884a131-87da-5381-61f3-d7acc3b91d76
Release:
https://sfa-gov-uk.visualstudio.com/Digital%20Apprenticeship%20Service/_releaseProgress?_a=release-environment-logs&releaseId=109008&environmentId=507412